### PR TITLE
test: uses *Queue instead of []Message in field struct in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module fairymq
 
 go 1.21.3
-
-require golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3

--- a/go.sum
+++ b/go.sum
@@ -1,1 +1,0 @@
-golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=

--- a/main.go
+++ b/main.go
@@ -120,7 +120,6 @@ func main() {
 	fairyMQ.RecoverQueues() // Recover persisted queues
 
 	fairyMQ.Wg.Wait() // Wait for all go routines
-
 }
 
 // SignalListener listens for system signals and gracefully shutsdown
@@ -212,7 +211,6 @@ func (fairyMQ *FairyMQ) RemoveExpired() {
 
 // SendToConsumers sends message to consumers of a queue
 func (fairyMQ *FairyMQ) SendToConsumers(queue string, data []byte, message *Message) {
-
 	for _, c := range fairyMQ.Consumers {
 		if c.Queue == queue {
 			attempts := 0 // Max attempts to reach server is 10
@@ -281,7 +279,6 @@ func (fairyMQ *FairyMQ) SendToConsumers(queue string, data []byte, message *Mess
 			if strings.HasPrefix(res, "ACK") {
 				message.AcknowledgedConsumers = append(message.AcknowledgedConsumers, c)
 			}
-
 		}
 	}
 }
@@ -326,14 +323,13 @@ func (fairyMQ *FairyMQ) RecoverQueues() {
 			return
 		}
 
-		for k, _ := range fairyMQ.Queues {
+		for k := range fairyMQ.Queues {
 			fairyMQ.QueueMutexes[k] = &sync.Mutex{}
 		}
 
 		log.Println("Recovered from snapshot")
 		break
 	}
-
 }
 
 // Snapshot takes a snapshot of current queue
@@ -416,7 +412,6 @@ func (fairyMQ *FairyMQ) StartUDPListener() {
 
 		for _, key := range keys {
 			if !key.IsDir() {
-
 				if strings.HasSuffix(key.Name(), "private.pem") {
 					privateKeyPEM, err := os.ReadFile("keys/" + key.Name())
 					if err != nil {
@@ -620,7 +615,6 @@ func (fairyMQ *FairyMQ) StartUDPListener() {
 					}
 				}
 			}
-
 		}
 
 		fairyMQ.Conn.WriteToUDP([]byte("NACK\r\n"), addr)
@@ -630,6 +624,5 @@ func (fairyMQ *FairyMQ) StartUDPListener() {
 
 	nack:
 		fairyMQ.Conn.WriteToUDP([]byte("NACK\r\n"), addr)
-
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -34,13 +34,12 @@ import (
 )
 
 func TestFairyMQ_GenerateQueueKeypair(t *testing.T) {
-
 	type fields struct {
 		UDPAddr       *net.UDPAddr
 		Conn          *net.UDPConn
 		Wg            *sync.WaitGroup
 		SignalChannel chan os.Signal
-		Queues        map[string][]Message
+		Queues        map[string]*Queue
 		ContextCancel context.CancelFunc
 		Context       context.Context
 	}
@@ -72,7 +71,6 @@ func TestFairyMQ_GenerateQueueKeypair(t *testing.T) {
 			if err := fairyMQ.GenerateQueueKeypair(tt.args.queue); (err != nil) != tt.wantErr {
 				t.Errorf("TestFairyMQ_GenerateQueueKeypair() error = %v, wantErr %v", err, tt.wantErr)
 			} else {
-
 				wd, err := os.Getwd()
 				if err != nil {
 					log.Println(err)
@@ -91,7 +89,6 @@ func TestFairyMQ_GenerateQueueKeypair(t *testing.T) {
 					t.Errorf("TestFairyMQ_GenerateQueueKeypair() error = %v", err)
 				}
 			}
-
 		})
 	}
 }
@@ -102,7 +99,7 @@ func TestFairyMQ_SignalListener(t *testing.T) {
 		Conn          *net.UDPConn
 		Wg            *sync.WaitGroup
 		SignalChannel chan os.Signal
-		Queues        map[string][]Message
+		Queues        map[string]*Queue
 		ContextCancel context.CancelFunc
 		Context       context.Context
 	}
@@ -150,7 +147,6 @@ func TestFairyMQ_SignalListener(t *testing.T) {
 			}()
 
 			fairyMQ.Wg.Wait()
-
 		})
 	}
 }
@@ -161,7 +157,7 @@ func TestFairyMQ_StartUDPListener(t *testing.T) {
 		Conn          *net.UDPConn
 		Wg            *sync.WaitGroup
 		SignalChannel chan os.Signal
-		Queues        map[string][]Message
+		Queues        map[string]*Queue
 		ContextCancel context.CancelFunc
 		Context       context.Context
 	}
@@ -221,7 +217,6 @@ func TestFairyMQ_StartUDPListener(t *testing.T) {
 			}()
 
 			fairyMQ.Wg.Wait()
-
 		})
 	}
 }


### PR DESCRIPTION
Fixed a compile error that on the test the queue map was of `map[string][]Message` while fairyMQ uses `map[string]*Queue` fixes the declaration of a fairymq passing tt.fields.Queue.

also ran the formatter `gofumtp` on main and `go mod tidy`